### PR TITLE
added fix for the headers and missing warnings

### DIFF
--- a/include/framework/ecs/component.h
+++ b/include/framework/ecs/component.h
@@ -33,7 +33,7 @@ namespace HGE {
 
     /* */
     template<typename C>
-    concept component = std::is_base_of<IComponent, C>::value;
+    concept ComponentConcept = std::is_base_of<IComponent, C>::value;
 
 }// namespace HGE
 

--- a/include/framework/ecs/component_array.h
+++ b/include/framework/ecs/component_array.h
@@ -34,7 +34,7 @@ namespace HGE {
      * todo: this is a friend class of Component manager, why? how are components added?
      * todo: rename to ComponentArrayImpl?
      */
-    template<component Comp>
+    template<ComponentConcept Comp>
     class ComponentArray : public IComponentArray {
         std::vector<std::unique_ptr<Comp>> mComponents;
         friend class ComponentArrayContainer;
@@ -84,7 +84,7 @@ namespace HGE {
 
     /* */
     template<typename C>
-    concept componentArray = std::is_base_of<IComponentArray, C>::value;
+    concept ComponentArrayConcept = std::is_base_of<IComponentArray, C>::value;
 }
 
 #endif //HESTIA_FRAMEWORK_ECS_COMPONENT_ARRAY_H

--- a/include/framework/ecs/component_array_container.h
+++ b/include/framework/ecs/component_array_container.h
@@ -32,7 +32,7 @@ namespace HGE {
 
         /* Creates a component Array for the type Comp, and stores it in the map.
          * Returns the pointer to the created component array. */
-        template<component Comp>
+        template<ComponentConcept Comp>
         ComponentArray<Comp> *createComponentArray() {
             auto type = typeid(Comp).name();
             mTypedComponentArrays[type] = std::make_unique<ComponentArray<Comp>>();
@@ -40,7 +40,7 @@ namespace HGE {
         }
 
         /* Retrieves a component array, returns nullopt if not present. */
-        template<component Comp>
+        template<ComponentConcept Comp>
         std::optional<ComponentArray<Comp> *> getComponentArray() {
             auto type = typeid(Comp).name(); // todo: can this be compile time?
             auto it = mTypedComponentArrays.find(type);

--- a/include/framework/ecs/interactors/component_array_interactor.h
+++ b/include/framework/ecs/interactors/component_array_interactor.h
@@ -12,7 +12,7 @@
 
 namespace HGE {
     /* */
-    template<component Comp>
+    template<ComponentConcept Comp>
     ComponentArray<Comp>* getOrCreateComponentArray(const Context* context) {
         auto array = context->mComponentManager->getComponentArray<Comp>();
         if(array.has_value()) {

--- a/include/framework/ecs/object.h
+++ b/include/framework/ecs/object.h
@@ -35,7 +35,7 @@ namespace HGE {
 
      //todo: A concept would allow better template definition for this object class
      template<typename O>
-     concept object = std::is_base_of<IObject, O>::value;
+     concept ObjectConcept = std::is_base_of<IObject, O>::value;
 }// namespace HGE
 
 #endif

--- a/include/framework/ecs/object_manager.h
+++ b/include/framework/ecs/object_manager.h
@@ -26,7 +26,7 @@ namespace HGE {
         ~ObjectManager() = default;
 
         /* Create an object of type 'Object' and add it to the array. Returns a pointer to the object. */
-        template<object Object>
+        template<ObjectConcept Object>
         Object *createObject() {
             auto objectPointer = std::make_unique<Object>(mContext);
             auto ptr = objectPointer.get();
@@ -38,7 +38,7 @@ namespace HGE {
 
         /* Retrieves an object by its id. It searches for the ID and returns the Object if found. */
         // todo: dynamic cast?
-        template<object Object>
+        template<ObjectConcept Object>
         [[maybe_unused]] std::optional<Object *> getObjectById(const UID id) const {
             constexpr auto func = [id](const std::unique_ptr<IObject> &pObject) {
                 return pObject->getId() == id;

--- a/include/framework/ecs/system.h
+++ b/include/framework/ecs/system.h
@@ -40,7 +40,7 @@ namespace HGE {
 
     /* */
     template<typename C>
-    concept system = std::is_base_of<ISystem, C>::value;
+    concept SystemConcept = std::is_base_of<ISystem, C>::value;
 }// namespace HGE
 
 #endif

--- a/include/framework/ecs/system_manager.h
+++ b/include/framework/ecs/system_manager.h
@@ -25,7 +25,7 @@ namespace HGE {
         SystemManager &operator=(const SystemManager &other) = delete;
 
         /* create a system for a given component. return the system if it already exists. */
-        template<component C, class... Args>
+        template<ComponentConcept C, class... Args>
         const System <C> *createSystem(Args &&... args) {
             auto type = typeid(System<C>).name();
             auto it = mTypedSystems.find(type);
@@ -39,12 +39,12 @@ namespace HGE {
         }
 
         /* TODO: Add method to delete a system by its templated class */
-        template<component C>
+        template<ComponentConcept C>
         void deleteSystem() {
         }
 
         /* TODO: Add method to get a system by its templated class */
-        template<component C>
+        template<ComponentConcept C>
         System <C> *getSystem() {
         }
 
@@ -52,8 +52,8 @@ namespace HGE {
         // todo: how are these systems ordered? should it have a zorder? or grouped into phases?
         // todo: extract to free function?
         void run(const double &deltaTime) const {
-            for (auto const &system : mTypedSystems) {
-                system.second->run(deltaTime);
+            for (auto const &typedSystem : mTypedSystems) {
+                typedSystem.second->run(deltaTime);
             }
         }
     };

--- a/include/game/game_envrionment.h
+++ b/include/game/game_envrionment.h
@@ -18,14 +18,14 @@ namespace HGE {
 
     public:
         /* RAII */
-        GameEnvironment(Context* context) : mContext(context) {}
+        explicit GameEnvironment(Context* context) : mContext(context) {}
 
         virtual ~GameEnvironment() = default;
 
         /* Called at the beginning of this game session */
         virtual void beginGame() = 0;
 
-        /* Runs continously during the game session */
+        /* Runs continuously during the game session */
         virtual void gameLoop(const double &deltaTime) = 0;
 
         /* Called when the game session ends */

--- a/include/game/systems/position_system.h
+++ b/include/game/systems/position_system.h
@@ -18,8 +18,8 @@ namespace HGE {
     struct PositionComponent : public IComponent {
         Transform2f mTransform;
 
-        const float &getX() { return mTransform.mLocalPosition.x; }
-        const float &getY() { return mTransform.mLocalPosition.y; }
+        [[nodiscard]] const float &getX() const { return mTransform.mLocalPosition.x; }
+        [[nodiscard]] const float &getY() const { return mTransform.mLocalPosition.y; }
         void setX(const float &value) { mTransform.mLocalPosition.x = value; }
         void setY(const float &value) { mTransform.mLocalPosition.y = value; }
 
@@ -32,11 +32,9 @@ namespace HGE {
      */
     template<>
     class System<PositionComponent> : public ISystem {
-        Context* mContext;
-        ComponentArray<PositionComponent> *mComponentsArray;
 
     public:
-        explicit System(Context* context, ComponentArray<PositionComponent> *componentArray) : mContext(context), mComponentsArray(componentArray) {
+        explicit System(Context* /*context*/, ComponentArray<PositionComponent> * /*componentArray*/) {
             Logger::instance()->logDebug("World Position System", "Created!");
         }
         ~System() override = default;

--- a/include/game/systems/tick_system.h
+++ b/include/game/systems/tick_system.h
@@ -26,11 +26,11 @@ namespace HGE {
      */
     template<>
     class System<TickComponent> : public ISystem {
-        Context* mContext;
+        //Context* mContext;
         ComponentArray<TickComponent> *mTickArray;
 
     public:
-        explicit System(Context* context, ComponentArray<TickComponent> *componentArray);
+        explicit System(Context* /*context*/, ComponentArray<TickComponent> *componentArray);
         ~System() override = default;
 
         void run(const double &deltaTime) override;

--- a/include/util/atomic_queue.h
+++ b/include/util/atomic_queue.h
@@ -25,7 +25,7 @@ public:
         return mQueue.front();
     }
 
-    long unsigned int size() {
+    size_t size() {
         std::lock_guard<std::mutex> lock(mMutex);
         return mQueue.size();
     }

--- a/include/util/logger.h
+++ b/include/util/logger.h
@@ -18,9 +18,9 @@ namespace HGE {
     class Logger {
         AtomicQueue<std::string> mMsgQueue;
         std::thread mThread;
-        bool mThreadRunning;
+        bool mThreadRunning{ true };
 
-        const long unsigned int maxMsgQueueSize = 1000;
+        const size_t maxMsgQueueSize = 1000;
         const size_t tagLength = 24;
 
         const std::string colourRed = "\033[31m";
@@ -38,7 +38,6 @@ namespace HGE {
         }
 
         Logger() {
-            mThreadRunning = true;
             mThread = std::thread(&Logger::loggingThreadLoop, this);
         }
 
@@ -64,15 +63,14 @@ namespace HGE {
             if (tag.size() > tagLength) {
                 std::string s = tag.substr(0, tagLength - 3) + "...";
                 return s;
-            } else {
-                std::string s = tag + std::string(tagLength - tag.size(), ' ');
-                return s;
             }
+            std::string s = tag + std::string(tagLength - tag.size(), ' ');
+            return s;
         }
 
     public:
-        static Logger *instance() {
-            static auto *sLogger = new Logger();
+        static const Logger *instance() {
+            static const auto *sLogger = new Logger();
             return sLogger;
         }
 

--- a/include/util/logger.h
+++ b/include/util/logger.h
@@ -69,8 +69,8 @@ namespace HGE {
         }
 
     public:
-        static const Logger *instance() {
-            static const auto *sLogger = new Logger();
+        static Logger *instance() {
+            static auto *sLogger = new Logger();
             return sLogger;
         }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,8 +7,9 @@ file(GLOB_RECURSE all_SRCS
 add_library(hestia STATIC ${all_SRCS} ../include)
 target_link_libraries(hestia PRIVATE
         hestia_project_options
-        project_warnings
+        hestia_project_warnings
         OpenGL::GL
+        PUBLIC
         athena
         CONAN_PKG::glm
         CONAN_PKG::glfw

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(hestia PRIVATE
         CONAN_PKG::glfw
         CONAN_PKG::stb
         glad)
-target_include_directories(hestia PUBLIC ../include)
+target_include_directories(hestia PUBLIC SYSTEM ../include)
 
 add_custom_command(
         TARGET hestia POST_BUILD

--- a/src/framework/systems/control_system.cpp
+++ b/src/framework/systems/control_system.cpp
@@ -33,8 +33,8 @@ namespace HGE {
     }
 
     void System<ControlComponent>::run(const double & /*deltaTime*/) {
-        for (auto &component : mComponentsArray->getComponents()) {
-            for (auto &[key, val] : component->mKeys) {
+        for (auto &components : mComponentsArray->getComponents()) {
+            for (auto &[key, val] : components->mKeys) {
                 val = mContext->mInputManager->getKeyValue(key);
             }
         }

--- a/src/framework/systems/control_system.cpp
+++ b/src/framework/systems/control_system.cpp
@@ -29,12 +29,12 @@ namespace HGE {
      */
     System<ControlComponent>::System(Context* context, ComponentArray<ControlComponent> *componentArray)
         : mContext(context), mComponentsArray(componentArray) {
-        Logger::instance()->logDebug("Control System", "Created");
+        LOG_DEBUG("Control System", "Created");
     }
 
     void System<ControlComponent>::run(const double & /*deltaTime*/) {
-        for (auto &components : mComponentsArray->getComponents()) {
-            for (auto &[key, val] : components->mKeys) {
+        for (auto &component : mComponentsArray->getComponents()) {
+            for (auto &[key, val] : component->mKeys) {
                 val = mContext->mInputManager->getKeyValue(key);
             }
         }

--- a/src/framework/systems/tick_system.cpp
+++ b/src/framework/systems/tick_system.cpp
@@ -6,7 +6,7 @@ namespace HGE {
     /**
      * Tick System Methods
      */
-    System<TickComponent>::System(Context* context, ComponentArray<TickComponent> *componentArray) : mContext(context), mTickArray(componentArray) {}
+    System<TickComponent>::System(Context* /*context*/, ComponentArray<TickComponent> *componentArray) : mTickArray(componentArray) {}
 
     void System<TickComponent>::run(const double &deltaTime) {
         for (auto &component : mTickArray->getComponents()) {


### PR DESCRIPTION
Overview:
Hestia would not compile as a sub module due to a missing cmake variable "project_warnings". Need to rename this to "Hestia_project warnings". Also some headers are missing, namely GLM. These are to be made public at the moment, but may be best hidden in future and abstracted away.

Changes Made:
- renamed project options.
- Made GLM, athena, GLFW public for modules to use.
- Renamed concepts to Pascal case and appended Concept i.e. "component" -> "ComponentConcept"
- Fixed size_t and unused parameter warnings in clang and msvc.
