### PR TITLE
Extract stb image to image loader interface

### DIFF
--- a/include/framework/ecs/interactors/component_array_interactor.h
+++ b/include/framework/ecs/interactors/component_array_interactor.h
@@ -10,7 +10,7 @@
 #include "context.h"
 #include "framework/ecs/component_array_container.h"
 
-namespace HGE {
+namespace HGE::ECS {
     /* */
     template<ComponentConcept Comp>
     ComponentArray<Comp>* getOrCreateComponentArray(const Context* context) {

--- a/include/framework/ecs/interactors/component_interactor.h
+++ b/include/framework/ecs/interactors/component_interactor.h
@@ -20,7 +20,7 @@ namespace HGE {
     namespace ECS {
 
         /* */
-        template<component Comp, typename... Args>
+        template<ComponentConcept Comp, typename... Args>
         Comp *createComponent(Context* context, Args... args) {
             auto array = context->mComponentManager->getComponentArray<Comp>();
             ComponentArray<Comp> *pArray;
@@ -35,7 +35,7 @@ namespace HGE {
         }
 
         /* */
-        template<component Comp>
+        template<ComponentConcept Comp>
         void destroyComponent(const Context* context, const UID objectId) {
             auto array = context->mComponentManager->getComponentArray<Comp>();
             if(array.has_value()) {
@@ -44,7 +44,7 @@ namespace HGE {
         }
 
         /* */
-        template<component Comp>
+        template<ComponentConcept Comp>
         void destroyComponent(const Context* context, const Comp *component) {
             auto array = context->mComponentManager->getComponentArray<Comp>();
             if(array.has_value()) {

--- a/include/framework/ecs/interactors/component_interactor.h
+++ b/include/framework/ecs/interactors/component_interactor.h
@@ -16,40 +16,39 @@
 #include "framework/ecs/component_array_container.h"
 #include "framework/ecs/system_manager.h"
 
-namespace HGE {
-    namespace ECS {
+namespace HGE::ECS {
 
-        /* */
-        template<ComponentConcept Comp, typename... Args>
-        Comp *createComponent(Context* context, Args... args) {
-            auto array = context->mComponentManager->getComponentArray<Comp>();
-            ComponentArray<Comp> *pArray;
+    /* */
+    template<ComponentConcept Comp, typename... Args>
+    Comp *createComponent(Context *context, Args... args) {
+        auto array = context->mComponentManager->getComponentArray<Comp>();
+        ComponentArray<Comp> *pArray;
 
-            if (array.has_value()) {
-                pArray = array.value();
-            } else {
-                pArray = context->mComponentManager->createComponentArray<Comp>();
-                context->mSystemManager->createSystem<Comp>(context, pArray);
-            }
-            return pArray->createComponent(std::forward<Args>(args)...);
+        if (array.has_value()) {
+            pArray = array.value();
+        } else {
+            pArray = context->mComponentManager->createComponentArray<Comp>();
+            context->mSystemManager->createSystem<Comp>(context, pArray);
         }
+        return pArray->createComponent(std::forward<Args>(args)...);
+    }
 
-        /* */
-        template<ComponentConcept Comp>
-        void destroyComponent(const Context* context, const UID objectId) {
-            auto array = context->mComponentManager->getComponentArray<Comp>();
-            if(array.has_value()) {
-                array.value()->deleteComponentWithOwner(objectId);
-            }
+    /* */
+    template<ComponentConcept Comp>
+    void destroyComponent(const Context *context, const UID objectId) {
+        auto array = context->mComponentManager->getComponentArray<Comp>();
+        if (array.has_value()) {
+            array.value()->deleteComponentWithOwner(objectId);
         }
+    }
 
-        /* */
-        template<ComponentConcept Comp>
-        void destroyComponent(const Context* context, const Comp *component) {
-            auto array = context->mComponentManager->getComponentArray<Comp>();
-            if(array.has_value()) {
-                array.value()->deleteComponentWithOwner(component->getOwnerUID());
-            }
+    /* */
+    // todo: also destroy system?
+    template<ComponentConcept Comp>
+    void destroyComponent(const Context *context, const Comp *component) {
+        auto array = context->mComponentManager->getComponentArray<Comp>();
+        if (array.has_value()) {
+            array.value()->deleteComponentWithOwner(component->getOwnerUID());
         }
     }
 }

--- a/include/framework/ecs/interactors/object_interactor.h
+++ b/include/framework/ecs/interactors/object_interactor.h
@@ -14,13 +14,13 @@ namespace HGE {
     namespace ECS {
 
         /* */
-        template<object obj>
+        template<ObjectConcept obj>
         obj *createObject(const Context* context) {
             return context->mObjectManager->createObject<obj>();
         }
 
         /* */
-        template<object obj>
+        template<ObjectConcept obj>
         std::optional<obj *> getObjectById(const Context* context, const UID &id) {
             return context->mObjectManager->getObjectById<obj>(id);
         }

--- a/include/framework/ecs/interactors/object_interactor.h
+++ b/include/framework/ecs/interactors/object_interactor.h
@@ -10,26 +10,25 @@
 #include "framework/ecs/object_manager.h"
 #include "context.h"
 
-namespace HGE {
-    namespace ECS {
+namespace HGE::ECS {
 
-        /* */
-        template<ObjectConcept obj>
-        obj *createObject(const Context* context) {
-            return context->mObjectManager->createObject<obj>();
-        }
+    /* */
+    template<ObjectConcept obj>
+    obj *createObject(const Context *context) {
+        return context->mObjectManager->createObject<obj>();
+    }
 
-        /* */
-        template<ObjectConcept obj>
-        std::optional<obj *> getObjectById(const Context* context, const UID &id) {
-            return context->mObjectManager->getObjectById<obj>(id);
-        }
+    /* */
+    template<ObjectConcept obj>
+    std::optional<obj *> getObjectById(const Context *context, const UID &id) {
+        return context->mObjectManager->getObjectById<obj>(id);
+    }
 
-        /* */
+    /* */
+    // todo: remove components also
 //        void destroyObject(Context* context, UID &id) {
 //            context->mObjectManager->destroyObject(id);
 //        }
-    }
 }
 
 #endif

--- a/include/game/game_object.h
+++ b/include/game/game_object.h
@@ -21,7 +21,7 @@ namespace HGE {
 
     public:
         /* RAII */
-        GameObject(Context* context) : mContext(context) {}
+        explicit GameObject(Context* context) : mContext(context) {}
 
         ~GameObject() override = default;
 

--- a/include/graphics/image_loader.h
+++ b/include/graphics/image_loader.h
@@ -1,0 +1,26 @@
+//
+// Created by david on 21/03/2021.
+//
+
+#ifndef HESTIA_BREAKOUT_IMAGE_LOADER_H
+#define HESTIA_BREAKOUT_IMAGE_LOADER_H
+
+#include <vector>
+#include <string>
+
+struct Image {
+    int width{ 0 };
+    int height{ 0 };
+    int channels{ 0 };
+    unsigned char* buffer;
+};
+
+class ImageLoader {
+
+public:
+    virtual Image loadImageFromFile(const char *filename) = 0;
+    virtual void freeImage(Image& image) = 0;
+    virtual ~ImageLoader() = default;
+};
+
+#endif //HESTIA_BREAKOUT_IMAGE_LOADER_H

--- a/include/graphics/opengl_module.h
+++ b/include/graphics/opengl_module.h
@@ -18,6 +18,8 @@
 #include "material.h"
 #include "maths/maths_types.h"
 #include "shader.h"
+#include "image_loader.h"
+#include "stb_image_loader.h"
 
 namespace HGE {
     class OpenglModule : public GraphicsModule {
@@ -27,11 +29,13 @@ namespace HGE {
         ScreenSize2f mResolution;
         std::map<std::pair<const char *, const char *>, std::unique_ptr<Shader>> mShaders;
         std::map<const char *, std::unique_ptr<Material>> mMaterials;
+        std::unique_ptr<ImageLoader> imageLoader;
 
     public:
         OpenglModule() : mResolution(ScreenSize2f(800, 600)),
                          mShaders(std::map<std::pair<const char *, const char *>, std::unique_ptr<Shader>>()),
-                         mMaterials(std::map<const char *, std::unique_ptr<Material>>()) { }
+                         mMaterials(std::map<const char *, std::unique_ptr<Material>>()),
+                         imageLoader(std::make_unique<StbImageLoader>()) { }
 
         ~OpenglModule() override = default;
 

--- a/include/graphics/stb_image_loader.h
+++ b/include/graphics/stb_image_loader.h
@@ -1,0 +1,18 @@
+//
+// Created by david on 21/03/2021.
+//
+
+#ifndef HESTIA_BREAKOUT_STB_IMAGE_LOADER_H
+#define HESTIA_BREAKOUT_STB_IMAGE_LOADER_H
+
+#include "image_loader.h"
+
+class StbImageLoader : public ImageLoader {
+public:
+    StbImageLoader();
+    ~StbImageLoader() override = default;
+    Image loadImageFromFile(const char *filename) override;
+    void freeImage(Image &image) override;
+};
+
+#endif //HESTIA_BREAKOUT_STB_IMAGE_LOADER_H

--- a/src/framework/systems/sprite_system.cpp
+++ b/src/framework/systems/sprite_system.cpp
@@ -7,7 +7,7 @@
 namespace HGE {
 
     System<SpriteComponent>::System(Context* context, ComponentArray<SpriteComponent> *componentArray) : mContext(context), mSpritesArray(componentArray) {
-        mPositionsArray = getOrCreateComponentArray<PositionComponent>(context);
+        mPositionsArray = ECS::getOrCreateComponentArray<PositionComponent>(context);
         mContext->mSystemManager->createSystem<PositionComponent>(mContext, mPositionsArray);
 
         mOrthographic = glm::ortho(mContext->mCameraManager->getViewportLeft(),

--- a/src/graphics/stb_image_loader.cpp
+++ b/src/graphics/stb_image_loader.cpp
@@ -1,0 +1,23 @@
+//
+// Created by david on 21/03/2021.
+//
+
+#include "graphics/stb_image_loader.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+
+StbImageLoader::StbImageLoader() {
+    stbi_set_flip_vertically_on_load(1);
+}
+
+Image StbImageLoader::loadImageFromFile(const char *filename) {
+    auto image = Image();
+    image.buffer = stbi_load(filename, &image.width, &image.height, &image.channels, 0);
+    return image;
+}
+
+// todo: pass out and in a unique pointer?
+void StbImageLoader::freeImage(Image &image) {
+    stbi_image_free(image.buffer);
+}


### PR DESCRIPTION
Overview:
Currently stb is coupled to the openGL implementation. Interfacing this allows it to be used in other graphics modules, as well as allowing it to be switched out.

Changes Made:
- Created image loader interface.
- moved stb methods to stb image loader.
- inlined HGE and ECS name spaces in interactors.